### PR TITLE
started backlog.org

### DIFF
--- a/backlog.org
+++ b/backlog.org
@@ -1,0 +1,79 @@
+* Ideas for future discussions
+** Emacs Lisp
+*** Edebug
+*** Profiling
+*** Test coverage
+*** Error Messages, Flycheck, etc.
+*** Asynchronous processing
+- Chaining HTTP requests
+*** Timers
+*** Package Management
+**** use-package
+**** quelpa
+**** straight.el
+*** Working with collections
+**** maps in elisp
+**** dash.el
+** Desktop Notifications
+** Completion frameworks
+*** Ivy
+*** Company
+*** Helm
+*** Selectrum
+*** Ido
+** Auto-expansion
+*** Dabbrev
+*** Hippie-expand
+*** Yasnippet
+** Window Management
+*** EXWM
+*** StumpWM
+*** i3
+** Emacs in OSX
+** Emacs in Windows
+** EAF (Emacs Application Framework)
+** PDF
+*** org-ref
+*** org-noter
+** Org-mode
+*** Org-roam
+*** LaTeX
+*** Babel
+** Web browsing
+** Search
+** Programming languages
+*** LSP
+** Chat
+*** IRC
+*** Telegram
+** Email
+*** notmuch
+*** Gnus
+*** mu4e
+** Emacs distributions
+*** Spacemacs
+*** Doom
+*** Prelude
+*** Ergoemacs
+** Theming
+** Hydra & Transient
+** Version Control
+- Magit
+- Ediff
+** Math in Emacs
+- Calc
+- Octave
+** Encryption and secrets
+** Shells and terminal emulators
+- eshell
+** FileTree
+*** Treemacs
+*** Neotree
+*** Direx
+** Emacs for Vimmers, Evil-mode
+*** Spacemacs
+*** Doom
+*** Evil-collection
+** TRAMP
+** Buffer management
+- iBuffer


### PR DESCRIPTION
Per discussion at the last meetup, I started a backlog. Right now, it's just a jumble of things; I hope we can improve this list and add more items. Perhaps later, we can add links to videos of discussions (when they happen), or maybe we can track the most knowledgeable individuals and invite them, hoping they'd show us some tricks. 
I'm not sure of the format; maybe at some point we can use Github issues per every item, that way, perhaps people feel more comfortable to open a discussion on a topic.